### PR TITLE
Hide Optional Fields If No Data Given

### DIFF
--- a/frontend/template/certified-shop.phtml
+++ b/frontend/template/certified-shop.phtml
@@ -38,9 +38,13 @@
         gts.push( ['google_base_subaccount_id', '<?php echo $this->escapeHtml( $this->getGoogleBaseSubaccountId() ) ?>'] );
     <?php endif; ?>
 
-    gts.push( ['google_base_country', '<?php echo $this->escapeHtml( $this->getGoogleBaseCountry() ) ?>'] );
+    <?php if( $this->getGoogleBaseCountry() ) : ?>
+        gts.push( ['google_base_country', '<?php echo $this->escapeHtml( $this->getGoogleBaseCountry() ) ?>'] );
+    <?php endif; ?>
 
-    gts.push( ['google_base_language', '<?php echo $this->escapeHtml( $this->getGoogleBaseLanguage() ) ?>'] );
+    <?php if( $this->getGoogleBaseLanguage() ) : ?>
+        gts.push( ['google_base_language', '<?php echo $this->escapeHtml( $this->getGoogleBaseLanguage() ) ?>'] );
+    <?php endif; ?>
 
     (function() {
         var gts = document.createElement('script');


### PR DESCRIPTION
Since the fields `google_base_country` and `google_base_language` are also optional (see https://support.google.com/trustedstoresmerchant/answer/6063080?p=badgecode), they should also be hidden if no data is given.
