### PR TITLE
Hide Optional Order Success Fields If No Data Given

### DIFF
--- a/frontend/template/order-success.phtml
+++ b/frontend/template/order-success.phtml
@@ -47,7 +47,9 @@
             <span class="gts-i-price"><?php echo $this->getPriceForItem( $item ) ?></span>
             <span class="gts-i-quantity"><?php echo $this->escapeHtml( $item->getQtyToInvoice() ) ?></span>
 
-            <span class="gts-i-prodsearch-id"><?php echo $this->escapeHtml( $item->getSku() ) ?></span>
+            <?php if( $this->getItemGoogleShoppingAccountId() ) : ?>
+                <span class="gts-i-prodsearch-id"><?php echo $this->escapeHtml( $item->getSku() ) ?></span>
+            <?php endif; ?>
 
             <?php if( $this->getItemGoogleShoppingAccountId() ) : ?>
                 <span class="gts-i-prodsearch-store-id"><?php echo $this->escapeHtml( $this->getItemGoogleShoppingAccountId() ) ?></span>


### PR DESCRIPTION
Since the field `ITEM_GOOGLE_SHOPPING_ID` is optional and should only be given if Google Shopping is used, (see https://support.google.com/trustedstoresmerchant/answer/6063087?p=ordercode), it should be hidden if Google Shopping is not used.
